### PR TITLE
Ready for release v.1.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_store
 node_modules
 .vscode
+.env

--- a/README.md
+++ b/README.md
@@ -49,13 +49,18 @@ scanner.startScanning()
 
 ## Complete API
 
-### scanner = new UsbScanner({vid, pid})
+### UsbScanner.showDevices()
 
-* Creates a new scanner using the VendorID and ProductID
+* Returns the devices connected to the computer. 
 
-### scanner = new UsbScanner({path})
+### scanner = new UsbScanner(options)
 
-* Creates a new scanner using at the specified path
+* Creates a new scanner using the options
+	* `vendorID` - *number* - the vendorID of the device
+	* `productID` - *number* - the productID of the device
+	* `path` - *string* the path of the devices
+	* `vCardString` -  *boolean* - default: `true` - If true returns vCards as one string, instead of separate strings.
+	* `vCardSeperator` *string* - default: `'|'` - If vCard string is true, this will be used as separation between the strings.
 
 ### scanner.startScanning()
 

--- a/index.js
+++ b/index.js
@@ -35,11 +35,25 @@ class UsbScanner extends EventEmitter {
 				} else if (characterValue === 40) {
 					let scanResult = barcode.join('');
 					barcode = [];
+					scanResult = removeUTF8(scanResult);
 					this.emit('data', scanResult);
 				}
 			}
 		});
 	}
 }
+
+function removeUTF8(barcode) {
+	let utf8 = barcode.slice(0, 7);
+	if (utf8 === '\\000026') {
+		barcode = barcode.slice(7);
+		return barcode;
+	} else return barcode;
+}
+
+
+
+
+
 
 module.exports = UsbScanner;

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const HID = require('node-hid').HID;
+const devices = require('node-hid').devices();
 const EventEmitter = require('events');
 const hidMap = require('./hidmap');
 
@@ -19,6 +20,11 @@ class UsbScanner extends EventEmitter {
 		// Bind 'this' to the methods
 		this.startScanning = this.startScanning.bind(this);
 	}
+
+	static showDevices() {
+		return devices;
+	}
+
 
 	startScanning() {
 		let barcode = [];
@@ -43,6 +49,7 @@ class UsbScanner extends EventEmitter {
 	}
 }
 
+
 function removeUTF8(barcode) {
 	let utf8 = barcode.slice(0, 7);
 	if (utf8 === '\\000026') {
@@ -50,10 +57,6 @@ function removeUTF8(barcode) {
 		return barcode;
 	} else return barcode;
 }
-
-
-
-
 
 
 module.exports = UsbScanner;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "usb-qrscanner",
+  "name": "@isirthijs/barcode-scanner",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -287,6 +287,12 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dotenv": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.0.0.tgz",
+      "integrity": "sha512-30xVGqjLjiUOArT4+M5q9sYdvuR4riM6yK9wMcas9Vbp6zZa+ocC9dp6QoftuhTPhFAiLK/0C5Ni2nou/Bk8lg==",
+      "dev": true
     },
     "emoji-regex": {
       "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A simple wedge barcode scanner module with support for the shift modifier key",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "sudo node ./test-utils/test.js"
   },
   "repository": {
     "type": "git",
@@ -20,6 +20,7 @@
     "node-hid": "^0.7.8"
   },
   "devDependencies": {
+    "dotenv": "^8.0.0",
     "eslint": "^5.16.0"
   },
   "eslintIgnore": [

--- a/test-utils/test.js
+++ b/test-utils/test.js
@@ -1,0 +1,14 @@
+const UsbScanner = require('../index');
+require('dotenv').config();
+
+const options = {
+	vendorID: process.env.VENDOR_ID,
+	productID: process.env.PRODUCT_ID,
+	path: undefined
+};
+
+const scanner = new UsbScanner(options);
+
+scanner.on('data', (data) => console.log(data)); //eslint-disable-line
+
+scanner.startScanning();

--- a/test-utils/test.js
+++ b/test-utils/test.js
@@ -4,14 +4,14 @@ require('dotenv').config();
 const options = {
 	vendorID: process.env.VENDOR_ID,
 	productID: process.env.PRODUCT_ID,
-	path: undefined
+	path: undefined,
 };
 
 const scanner = new UsbScanner(options);
 
 scanner.on('data', (data) => console.log(data)); //eslint-disable-line
 
-let devices = UsbScanner.showDevices();
-console.log(devices); 
+// let devices = UsbScanner.showDevices();
+// console.log(devices); 
 
 scanner.startScanning();

--- a/test-utils/test.js
+++ b/test-utils/test.js
@@ -11,4 +11,7 @@ const scanner = new UsbScanner(options);
 
 scanner.on('data', (data) => console.log(data)); //eslint-disable-line
 
+let devices = UsbScanner.showDevices();
+console.log(devices); 
+
 scanner.startScanning();


### PR DESCRIPTION
This release adds some new functionality

- A method that returns devices on the computer (so you can see the VID/PID)
- vCard support:
  - A scanned vCard now returns one string containing all data
  - this behaviour is default on but can be turned off by passing `vCardString: false` into the options object
  - The default separation is a pipe character `'|'`, but can be changed by passing `vCardSeparator: <string>` into the options object
- UTF8 Character coding is removed
- Added a test environment
