### PR TITLE
v1.2.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ scanner.startScanning()
 
 ### scanner = new UsbScanner(options)
 
-* Creates a new scanner using the options
+* Creates and opens a new scanner using the options
 	* `vendorID` - *number* - the vendorID of the device
 	* `productID` - *number* - the productID of the device
 	* `path` - *string* the path of the devices
@@ -65,6 +65,10 @@ scanner.startScanning()
 ### scanner.startScanning()
 
 * Starts listening for barcodes
+
+### scanner.stopScanning()
+
+* Stops listening for barcodes and closes the HID device.
 
 ### scanner.on('data', functions(data) {})
 

--- a/index.js
+++ b/index.js
@@ -71,7 +71,14 @@ class UsbScanner extends EventEmitter {
 				}
 			}
 		});
+		
 	}
+
+	stopScanning() {
+		this.hid.removeAllListeners('data');
+		this.hid.close();
+	}
+
 }
 
 

--- a/index.js
+++ b/index.js
@@ -6,22 +6,23 @@ const hidMap = require('./hidmap');
 class UsbScanner extends EventEmitter {
 
 	constructor(options) {
+		options = options || {};
+
 		let { 
-			vendorID,
-			productID,
-			path,
+			vendorID = undefined,
+			productID = undefined,
+			path = undefined, 
 			vCardString = true,
 			vCardSeperator = '|'
 		} = options;
-		
+
 		super();
 
+		this.vendorID = vendorID;
+		this.productID = productID;
+		this.path = path;
 		this._vCardString = vCardString;
 		this._vCardSeperator = vCardSeperator;
-
-		if(path) this.hid = new HID(path);
-		else if (vendorID && productID) this.hid = new HID(vendorID, productID);
-		else console.error('Device cannot be found, please supply a path or VID & PID'); // eslint-disable-line
 
 		this._hidMap = hidMap.standard;
 		this._hidMapShift = hidMap.shift;
@@ -36,6 +37,14 @@ class UsbScanner extends EventEmitter {
 
 
 	startScanning() {
+		try {
+			if(this.path) this.hid = new HID(path);
+			else if (this.vendorID && this.productID) this.hid = new HID(this.vendorID, this.productID);
+			else throw 'Device cannot be found, please supply a path or VID & PID';
+		} catch(error) {
+			this.emit('error', error);
+		}
+		
 		let scanResult = [];
 		let vCard = [];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@isirthijs/barcode-scanner",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@isirthijs/barcode-scanner",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A simple wedge barcode scanner module with support for the shift modifier key",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This release adds a method to stop scanning and close the HID. (so you can reuse the scanner somewhere else) and it passes through error events from node-hid